### PR TITLE
feat(moon-bucks): implement step1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+.idea

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,86 @@
+const $ = (selector) => document.querySelector(selector)
+
+function App() {
+    const updateMenuCount = () => {
+        const menuCount = document.querySelectorAll('.menu-list-item').length
+
+        $('.menu-count').innerText = `총 ${menuCount}개`
+    }
+
+    const addMenu = () => {
+        const menuName = document
+            .querySelector('#espresso-menu-name')
+            .value
+
+        if (menuName === '') {
+            alert('메뉴 이름을 입력해주세요.')
+
+            return
+        }
+
+        $('#espresso-menu-list')
+            .insertAdjacentHTML('beforeend',
+                `
+                <li class="menu-list-item d-flex items-center py-2">
+                  <span class="w-100 pl-2 menu-name">${menuName}</span>
+                  <button
+                    type="button"
+                    class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
+                  >
+                    수정
+                  </button>
+                  <button
+                    type="button"
+                    class="bg-gray-50 text-gray-500 text-sm menu-remove-button"
+                  >
+                    삭제
+                  </button>
+                </li>
+                `
+            )
+
+        $('#espresso-menu-name').value = ''
+
+        updateMenuCount()
+    }
+
+    const editMenu = (e) => {
+        const $menuNameElement = e.target.closest('li').querySelector('.menu-name')
+
+        $menuNameElement.innerText = prompt('메뉴명을 수정해주세요', $menuNameElement.innerText)
+    }
+
+    const removeMenu = (e) => {
+        if (confirm('정말 삭제하시겠습니까?')) {
+            e.target.closest('li').remove()
+
+            updateMenuCount()
+        }
+    }
+
+    $("#espresso-menu-form").addEventListener('submit', e => {
+        e.preventDefault()
+    })
+
+    $('#espresso-menu-submit-button').addEventListener('click', addMenu)
+
+    $('#espresso-menu-name').addEventListener('keypress', (e) => {
+        if (e.key !== 'Enter') {
+            return
+        }
+
+        addMenu()
+    })
+
+    $('#espresso-menu-list').addEventListener('click', e => {
+        if (e.target.classList.contains('menu-edit-button')) {
+            editMenu(e)
+        }
+
+        if (e.target.classList.contains('menu-remove-button')) {
+            removeMenu(e)
+        }
+    })
+}
+
+App()


### PR DESCRIPTION
## 🎯 step1 요구사항 - 돔 조작과 이벤트 핸들링으로 메뉴 관리하기

- [X] 에스프레소 메뉴에 새로운 메뉴를 확인 버튼 또는 엔터키 입력으로 추가한다.
  - [X] 메뉴가 추가되고 나면, input은 빈 값으로 초기화한다.
  - [X] 사용자 입력값이 빈 값이라면 추가되지 않는다.
- [X] 메뉴의 수정 버튼을 눌러 메뉴 이름 수정할 수 있다.
  - [X] 메뉴 수정시 브라우저에서 제공하는 `prompt` 인터페이스를 활용한다.
- [X] 메뉴 삭제 버튼을 이용하여 메뉴 삭제할 수 있다.
  - [X] 메뉴 삭제시 브라우저에서 제공하는 `confirm` 인터페이스를 활용한다.
- [X] 총 메뉴 갯수를 count하여 상단에 보여준다.